### PR TITLE
Dockerfile and cloudbuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# For more information on these images, and use of Clojure in Docker
+# https://hub.docker.com/_/clojure
+FROM clojure:openjdk-11-lein AS builder
+
+# Copying and building deps as a separate step in order to mitigate
+# the need to download new dependencies every build.
+COPY project.clj /usr/src/app/project.clj
+WORKDIR /usr/src/app
+RUN lein deps 
+
+
+COPY . /usr/src/app
+RUN lein uberjar
+
+# Using image without lein for deployment.
+FROM openjdk:11
+MAINTAINER Clingen Developers <clingendevs@broadinstitute.org>
+
+COPY --from=builder /usr/src/app/target/uberjar/app.jar /app/app.jar
+# COPY keys/dev.serveur.keystore.jks /keys/dev.serveur.keystore.jks
+# COPY keys/serveur.truststore.jks /keys/serveur.truststore.jks
+
+# EXPOSE 8080
+
+# CMD ["java", "-jar", "/app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,7 @@ FROM openjdk:11
 MAINTAINER Clingen Developers <clingendevs@broadinstitute.org>
 
 COPY --from=builder /usr/src/app/target/uberjar/app.jar /app/app.jar
-# COPY keys/dev.serveur.keystore.jks /keys/dev.serveur.keystore.jks
-# COPY keys/serveur.truststore.jks /keys/serveur.truststore.jks
 
-# EXPOSE 8080
+EXPOSE 3000
 
-# CMD ["java", "-jar", "/app/app.jar"]
+CMD ["java", "-jar", "/app/app.jar", "-w"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,23 @@
+# Cloud Build configuration for clinvar-submitter
+#
+# Command line test usage:
+# gcloud builds submit --project=clingen-stage --config ./cloudbuild.yaml \
+#  --substitutions=COMMIT_SHA="testbuild" .
+
+# Builds clinvar-submitter and tags for both stage and prod image repositories
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '.', '-t', 'clinvar-submitter:$COMMIT_SHA']
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'tag', 'clinvar-submitter:$COMMIT_SHA', 'gcr.io/clingen-stage/clinvar-submitter:$COMMIT_SHA']
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'tag', 'clinvar-submitter:$COMMIT_SHA', 'gcr.io/clingen-dx/clinvar-submitter:$COMMIT_SHA']
+
+# push the images
+images:
+  - 'gcr.io/clingen-stage/clinvar-submitter:$COMMIT_SHA'
+  - 'gcr.io/clingen-dx/clinvar-submitter:$COMMIT_SHA'
+
+# timeout if not complete in 30 minutes
+timeout: 1800s
+

--- a/project.clj
+++ b/project.clj
@@ -24,4 +24,5 @@
   :ring {:handler clinvar-submitter.web-service/app}
   :plugins [[lein-ring "0.12.1"]]
   :target-path "target/%s"
-  :profiles {:uberjar {:aot :all}})
+  :profiles {:uberjar {:aot :all
+                       :uberjar-name "app.jar"}})


### PR DESCRIPTION
Adds a docker file and cloudbuild config, to support later work for deploying the submitter on kubernetes.

It looks like leiningen projects are pretty consistent in general -- I was able to steal much prior art from the genegraph build. Aside from the two additional files, there's one small change to the project definition that normalizes the name of the uberjar output file to `app.jar`, which makes building the container more consistent.