### PR TITLE
adds a docker linter to the cloudbuild pipeline

### DIFF
--- a/.cloudbuild/docker-build.cloudbuild.yaml
+++ b/.cloudbuild/docker-build.cloudbuild.yaml
@@ -6,9 +6,6 @@
 
 # Builds clinvar-submitter and tags for both stage and prod image repositories
 steps:
-- name: 'hadolint/hadolint'
-  entrypoint: '/bin/hadolint'
-  args: [ './Dockerfile']
 - name: 'gcr.io/cloud-builders/docker'
   args: [ 'build', '.', '-t', 'clinvar-submitter:$COMMIT_SHA']
 - name: 'gcr.io/cloud-builders/docker'

--- a/.cloudbuild/pull-request.cloudbuild.yaml
+++ b/.cloudbuild/pull-request.cloudbuild.yaml
@@ -1,0 +1,11 @@
+# Pull request checks for clinvar-submitter
+#
+# Command line test usage:
+# gcloud builds submit --project=clingen-stage --config .cloudbuild/pull-request.cloudbuild.yaml \
+# .
+
+# Builds clinvar-submitter and tags for both stage and prod image repositories
+steps:
+- name: 'hadolint/hadolint'
+  entrypoint: '/bin/hadolint'
+  args: [ './Dockerfile']

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN lein uberjar
 
 # Using image without lein for deployment.
 FROM openjdk:11
-MAINTAINER Clingen Developers <clingendevs@broadinstitute.org>
+LABEL maintainer="Clingen Developers <clingendevs@broadinstitute.org>"
 
 COPY --from=builder /usr/src/app/target/uberjar/app.jar /app/app.jar
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,6 +6,9 @@
 
 # Builds clinvar-submitter and tags for both stage and prod image repositories
 steps:
+- name: 'hadolint/hadolint'
+  entrypoint: '/bin/hadolint'
+  args: [ './Dockerfile']
 - name: 'gcr.io/cloud-builders/docker'
   args: [ 'build', '.', '-t', 'clinvar-submitter:$COMMIT_SHA']
 - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
I'm starting to standardize a bunch of the TGG projects around using https://github.com/hadolint/hadolint for linting our docker images. I decided to use the submitter as a first stop, since it was a simple pipeline.

In case it's helpful, hadolint works with a bunch of text editor linting tools (including vscode, Emacs/flycheck, vim, etc): https://github.com/hadolint/hadolint/blob/master/docs/INTEGRATION.md#editors