### PR TITLE
Upgrade GCP cloudfunction to gen2

### DIFF
--- a/gcp/function-source/cloudbuild.yaml
+++ b/gcp/function-source/cloudbuild.yaml
@@ -3,7 +3,20 @@
 # Build copies the modified cloud function into place in production cluster
 # TODO: Testing strategy possible with pytest? And mock of BigQuery?
 steps:
-- name: 'gcr.io/cloud-builders/gcloud'
-  args: ['functions', 'deploy', 'ClinVarSCV', '--trigger-http', '--memory=512MB', '--min-instances=1', '--runtime', 'python37', '--entry-point', 'findByLocalKey']
-  dir: 'gcp/function-source'
-  
+  - name: "gcr.io/cloud-builders/gcloud"
+    args:
+      [
+        "functions",
+        "deploy",
+        "clinvarscv",
+        "--trigger-http",
+        "--gen2",
+        "--timeout=60s",
+        "--memory=512MB",
+        "--min-instances=1",
+        "--runtime",
+        "python37",
+        "--entry-point",
+        "findByLocalKey",
+      ]
+    dir: "gcp/function-source"

--- a/gcp/function-source/requirements.txt
+++ b/gcp/function-source/requirements.txt
@@ -1,6 +1,6 @@
 # Function dependencies, for example:
 # package>=version
-google-cloud-bigquery
-pandas
-pyarrow
-db-dtypes
+google-cloud-bigquery==3.4.1
+pandas==1.3.5
+pyarrow==10.0.1
+db-dtypes==1.0.5


### PR DESCRIPTION
In light of the recent timeout/cold start complaints from some of our users, I think it's a good idea to try upgrading this clinvarSCV function to a "2nd generation" cloudfunction.

Among other things, 2nd gen functions allow for up to 1000 concurrent requests to the same function instance, so this should theoretically improve the issues you can see in the metrics where we get ~30 requests in short order, and then finish scaling up too late. We recently configured this function to require a minimum of 1 instance running at all times, but I'm not confident that it will help if we're limited to 1 execution per instance.

https://cloud.google.com/functions/docs/concepts/version-comparison#comparison-table

Aside from the `--gen2` flag, I've:

- pinned the python dependencies in requirements.txt to specific versions -- apparently this can help with function build/startup times because it has a better chance of a cache hit for specific package versions.
- renamed the function to all lowercase letters, since apparently 2nd gen cloudfunctions don't support capital letters in the name
- Upped the timeout to 60 seconds. New cloudfunctions default to this, but upgrading from an old function apparently keeps the old default of 15 seconds.

I think @larrybabb has the most state here, but I'm tagging @toneillbroad too since he seems to have looked at this function recently as well.

New generation cloudfunctions will end up with a different URL than the old ones -- I'll submit a follow up PR in the architecture repo that points the clinvar-submitter clojure service to the right place.