### PR TITLE
Release 1.2.0: Update ClinVar template column mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Not supported in this release
 5.	No sorting of summarized met strength codes.
 6.  No support yet for multiple file or directory input.
 
+### 11.Sep.2025
+#### (fixed) Update ClinVar template column mappings to match current template
+*these are the specific column changes*
+* Mode of inheritance: AK → AL
+* Classification citations: AL → AM  
+* Citations or URLs for classification: AM → AN
+* Comment on classification: AN → AK
+
 ### 08.Aug.2025
 #### (fixed) Remove functional consequence columns to match current ClinVar submission template format
 *these are the specific column changes*

--- a/doc/submitter-sheet-field-mapping.md
+++ b/doc/submitter-sheet-field-mapping.md
@@ -31,6 +31,7 @@ Shortcut notations for mapping.
 | Date last evaluated (AL) | Interp.contribution.contributionDate | if the Interp.contribution.contributionDate does not found an E-403 exception will be raised. The final format will be yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXX if no time portion is available then just the yyyy-MM-dd will be produced. |
 | Assertion method (AM) | <assertion method provided by caller> | Not pulled from the Interp record since it is unavailable, a value can be specified but the default will be "ACMG Guidelines, 2015".  |
 | Assertion method citation (AN) | <method citation provided by caller> | Like the Assertion method the method citation is not available, so a value can be specified for all records, it defaults to "PMID:25741868". |
-| Mode of inheritance (AO) | (get condition :moi) | |
-| Clinical significance citations (AP) | (get evidence :pmid-citations) | |
-| Comment on clinical significance (AR) | (get evidence :summary) | |
+| Comment on clinical significance (AK) | (get evidence :summary) | |
+| Mode of inheritance (AL) | (get condition :moi) | |
+| Clinical significance citations (AM) | (get evidence :pmid-citations) | |
+| Citations or URLs for clinical significance (AN) | | |

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clinvar-submitter "1.1.0"
+(defproject clinvar-submitter "1.2.0"
   :description "ClinGen ClinVar variant submission generation tool"
   :url "https://github.com/clingen-data-model/clinvar-submitter"
   :license {:name "Eclipse Public License"

--- a/src/clinvar_submitter/variant.clj
+++ b/src/clinvar_submitter/variant.clj
@@ -62,12 +62,12 @@
      (:significance interp) ; (AH) Clinical significance
      "" ; Assertion score
      (:eval-date interp)    ; (AJ) Date last evaluated
-     (:moi condition "")    ; (AK) Mode of Inheritance
-     (form/get-pmid-list evidence) ; (AL) significance citations
-     (str "https://erepo.clinicalgenome.org/evrepo/ui/interpretation/" (:id interp)) ; (AM) Citations or URLs for clinical significance
      (if (some? (:description interp))
        (:description interp)
-       (form/summary-string evidence interp variant condition method approver)) ; (AN) comment on clinical significance
+       (form/summary-string evidence interp variant condition method approver)) ; (AK) comment on clinical significance
+     (:moi condition "")    ; (AL) Mode of Inheritance
+     (form/get-pmid-list evidence) ; (AM) significance citations
+     (str "https://erepo.clinicalgenome.org/evrepo/ui/interpretation/" (:id interp)) ; (AN) Citations or URLs for clinical significance
      "" ; explanation if clinsig is other or drug
      "" ; drug response condition
      "" ; empty


### PR DESCRIPTION
## Summary
- Update ClinVar submission template column mappings to match current format
- Move Mode of inheritance from AK to AL  
- Move Classification citations from AL to AM
- Move Citations or URLs from AM to AN
- Move Comment on classification from AN to AK
- Increment version to 1.2.0 with release notes

## Changes Made
- **src/clinvar_submitter/variant.clj**: Updated column assignments in `construct-variant` function
- **doc/submitter-sheet-field-mapping.md**: Updated documentation to reflect new column positions
- **project.clj**: Incremented version from 1.1.0 to 1.2.0
- **README.md**: Added release notes documenting the column mapping changes

## Test Plan
- [x] Compilation successful (`lein compile`)
- [x] Build successful (`lein uberjar`) 
- [x] Application starts without errors
- [x] Column mappings verified in code

## Impact
This ensures the application generates ClinVar submission files that match the current template format, preventing column misalignment issues during submission.

## Reviewers
Please assign Terry O'Neill and Kyle Ferriter as reviewers.

🤖 Generated with [Claude Code](https://claude.ai/code)